### PR TITLE
Add Dependabot version updates and CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @yuyuyuyuyu-dev

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+
+updates:
+  # A single directory is enough for Gradle: every dependency and plugin version lives
+  # in gradle/libs.versions.toml, and the subprojects only reference catalog aliases.
+  - package-ecosystem: gradle
+    directory: "/"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 1
+
+  - package-ecosystem: github-actions
+    directories:
+      - "/"
+      # "/" only covers .github/workflows, so the composite actions under
+      # .github/actions have to be listed separately to be updated at all.
+      - "/.github/actions/*"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 1


### PR DESCRIPTION
## What changed

- `.github/dependabot.yml`: daily version updates for the Gradle and GitHub Actions ecosystems, each capped at one open pull request.
- `.github/CODEOWNERS`: `* @yuyuyuyuyu-dev` as the default reviewer for the whole repository.

## Why

Dependency updates were done by hand, so they only happened when someone remembered to look. A daily check keeps updates flowing, and the limit of one open pull request per ecosystem keeps the review queue small — Dependabot moves on to the next dependency after each merge.

## Notes for reviewers

- The Gradle entry only lists the root directory. Every version lives in `gradle/libs.versions.toml`, which Dependabot reads, and the four subprojects reference catalog aliases rather than versions of their own.
- The GitHub Actions entry lists `/.github/actions/*` in addition to `/`. The root directory covers only `.github/workflows`, so without the extra entry the actions used inside the `setup-build` and `build-distribution` composite actions (`actions/setup-java`, `gradle/actions`, `actions/setup-node`) would stay pinned forever.
- No npm entry. `kotlin-js-store/wasm/yarn.lock` is generated by the Kotlin/JS toolchain and there is no `package.json`, so Dependabot has nothing to update there.
- No `groups` configuration, since it was not requested. Adding it later would let a single pull request carry several updates at once if the one-at-a-time pace feels slow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)