### PR TITLE
ci: group and auto-merge minor and patch Dependabot updates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* @yuyuyuyuyu-dev

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,13 @@ updates:
     schedule:
       interval: daily
     open-pull-requests-limit: 1
+    groups:
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
 
   - package-ecosystem: github-actions
     directories:
@@ -18,3 +25,10 @@ updates:
     schedule:
       interval: daily
     open-pull-requests-limit: 1
+    groups:
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,42 @@
+name: Dependabot auto-merge
+
+# pull_request_target rather than pull_request: a run triggered by Dependabot on
+# pull_request cannot read Actions secrets, which would put the App private key out of
+# reach. Nothing from the pull request is checked out or executed here, so the elevated
+# context stays harmless.
+on:
+  pull_request_target:
+    branches: ["main"]
+
+jobs:
+  auto-merge:
+    name: Enable auto-merge
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v3
+
+      # Merging goes through the yuyuyuyuyu-dev-pr-bot App instead of GITHUB_TOKEN,
+      # because a merge made with GITHUB_TOKEN does not trigger CI on main, and Deploy
+      # only runs after CI.
+      - name: Create App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.PR_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.PR_BOT_PRIVATE_KEY }}
+
+      # A grouped pull request reports the highest update type it carries, so this also
+      # keeps a group that somehow contains a major update from merging on its own.
+      - name: Enable auto-merge
+        if: >-
+          steps.metadata.outputs.update-type == 'version-update:semver-minor' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-patch'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: gh pr merge --auto --squash "$PR_URL"


### PR DESCRIPTION
Groups every minor and patch Dependabot update into a single pull request per ecosystem, and merges those pull requests automatically with squash once the checks pass. Also removes `CODEOWNERS`.

## Why

Minor and patch bumps each arrived as their own pull request and still had to be merged by hand, even though the update was routine either way. Grouping them leaves one pull request to look at instead of several, and auto-merge takes even that one off the queue, so what remains for review is the major updates that actually want a look.

## What changed

`.github/dependabot.yml` gains a `minor-and-patch` group on both the Gradle and the GitHub Actions entry, matching all dependencies with `update-types: [minor, patch]`. Major updates are unaffected and keep coming as individual pull requests.

`.github/workflows/dependabot-auto-merge.yml` is new. On a Dependabot pull request it reads the update type with `dependabot/fetch-metadata`, and for a minor or patch update runs `gh pr merge --auto --squash`. GitHub then merges the pull request once the required checks pass; nothing is merged ahead of CI.

`.github/CODEOWNERS` is removed. It only made the repository owner the default reviewer on every pull request, and reviews are not required to merge.

## Notes for the reviewer

**`pull_request_target`, not `pull_request`.** A workflow run triggered by Dependabot on `pull_request` can only read Dependabot secrets, not Actions secrets, so `PR_BOT_PRIVATE_KEY` would be out of reach and the App token could not be minted. `pull_request_target` is documented as not carrying that restriction, and it is what `dependabot/fetch-metadata` recommends for write operations. The usual risk of that event does not apply here: nothing from the pull request is checked out or executed, and the only untrusted-looking value used is `github.event.pull_request.html_url`, which GitHub generates and which is passed through the environment rather than interpolated into the script. Keeping the existing Actions secret and variable also means no second copy of the private key has to live in Dependabot secrets.

**Why the App and not `GITHUB_TOKEN`.** A merge performed with `GITHUB_TOKEN` does not trigger CI on `main`, and Deploy runs off CI completing, so the site would stop being deployed on these merges. The same `yuyuyuyuyu-dev-pr-bot` App as the Wasm lock file workflow is used instead. No new secret or variable is needed.

**A grouped pull request reports the highest update type it carries**, so a group that somehow contained a major update would not merge on its own.

**Setup already done on the repository:** `Allow auto-merge` is now enabled (auto-merge cannot be turned on without it), and `Run Tests` was added alongside `Build Distribution` as a required status check, so a failing test now blocks these merges too.

This workflow only takes effect once it is on `main`, since `pull_request_target` runs the base branch's copy. It does not act on this pull request.

## Verification

- `actionlint` reports nothing beyond the `client-id` false positive it already reports for the existing `update-wasm-yarn-lock.yml`; its bundled metadata for `actions/create-github-app-token@v3` predates the `app-id` to `client-id` rename.
- Both YAML files parse.
- Confirmed against the action's source that `update-type` is the highest semver level across all dependencies in the pull request, which is what makes the check sound for grouped updates.
- Confirmed `dependabot/fetch-metadata@v3` differs from `v2` only in requiring the Node 24 runtime.
- Checked the repository state through the API: auto-merge and squash merging enabled, required checks now `Build Distribution` and `Run Tests`, no required reviews and no bypass actors in the `main` ruleset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
